### PR TITLE
[Modified] tsconfig.jsonについて依存関係を追加

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,11 @@
 [build]
   functions = "netlify/functions"
+  command = "npm run build"
+
+[dev]
+  functions = "netlify/functions"
+
+[[redirects]]
+  from = "/api/weather"
+  to = "/.netlify/functions/weather"
+  status = 200

--- a/netlify/functions/weather.ts
+++ b/netlify/functions/weather.ts
@@ -49,6 +49,7 @@ export const handler: Handler = async (event) => {
 
     //天気情報を取得
     const weatherResponse = await fetch(`${WEATHER_API_URL}?lat=${lat}&lon=${lon}&appid=${API_KEY}`);
+
     const weatherData = await weatherResponse.json() as WeatherData;
 
     return {
@@ -64,8 +65,12 @@ export const handler: Handler = async (event) => {
       }),
     };
 
-  }catch (error) {
-    console.error(error);
+  }catch (error: unknown) {
+    if (error instanceof Error) {
+      console.error(error.message);
+    } else {
+      console.error("Unexpected error", error);
+    }
     return {
       statusCode: 500,
       body: JSON.stringify({error: "サーバーエラーが発生しました"})

--- a/src/functions/App.tsx
+++ b/src/functions/App.tsx
@@ -1,8 +1,8 @@
 import {useState} from "react"
-import Title from "./components/Title"
-import Form from "./components/Form"
-import Result from "./components/Result"
-import Loading from "./components/Loading"
+import Title from "../components/Title.tsx"
+import Form from "../components/Form.tsx"
+import Result from "../components/Result.tsx"
+import Loading from "../components/Loading.tsx"
 
 type ResultState = {
   weather:string

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
-import App from './App.tsx'
+import App from './functions/App.tsx'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -4,11 +4,11 @@
     "target": "ES2020",
     "useDefineForClassFields": true,
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
-    "module": "ESNext",
+    "module": "NodeNext",
     "skipLibCheck": true,
 
     /* Bundler mode */
-    "moduleResolution": "bundler",
+    "moduleResolution": "NodeNext",  // ここを修正
     "allowImportingTsExtensions": true,
     "isolatedModules": true,
     "moduleDetection": "force",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "files": [],
+  "compilerOptions": {"composite": true},
   "references": [
     { "path": "./tsconfig.app.json" },
     { "path": "./tsconfig.node.json" }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -3,25 +3,25 @@
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
     "target": "ESNext",
     "lib": ["ESNext"],
-    "module": "ESNext",
+    "module": "NodeNext",
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "outDir": "dist",
+    "outDir": "./dist",
 
     /* Bundler mode */
-    "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
+    "moduleResolution": "NodeNext",
     "isolatedModules": true,
     "moduleDetection": "force",
-    "noEmit": true,
+    "noEmit": false,  // ここを false にする！
+    "allowJs": true,  // 必要なら追加
+    "strict": true,
 
     /* Linting */
-    "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["netlify/functions"]
+  "include": ["netlify/functions"]  // 必ず netlify/functions を含める
 }


### PR DESCRIPTION
デプロイ後、gistフォルダ直下にjsファイルが作成されていないことによる404エラーが発生。
tsconfig.jsonについて「composite: true 」を追加し、TypeScript が tsconfig.app.json と tsconfig.node.json の参照関係を正しく理解できるようにした。
また、tsconfig.node.json について、 noEmit: falseに修正し、jsファイルが正しく修正できたことを確認した。